### PR TITLE
Helmholtz resonance frequency

### DIFF
--- a/acoustician_tools/utils.py
+++ b/acoustician_tools/utils.py
@@ -93,3 +93,11 @@ def shoebox_surfaces(length: float, width: float, height: float) -> list:
 
     surfaces = [sidewalls, sidewalls, front_rear, front_rear, roof_ceil, roof_ceil]
     return surfaces
+
+
+def cot(x):
+    return 1 / np.tan(x)
+
+
+def coth(x):
+    return np.cosh(x) / np.sinh(x)

--- a/tests/test_absorber.py
+++ b/tests/test_absorber.py
@@ -43,6 +43,33 @@ class TestAbsorber(unittest.TestCase):
         )
         np.testing.assert_almost_equal(expected, calculated, decimal=2)
 
+    def test_helmholtz_frequency(self):
+        expected = 240.092
+        calculated = helmholtz_resonant_frequency(
+            opening_diameter=(10 * 2),
+            opening_length=20,
+            cavity_dimensions=[40, 500],
+            opening_shape='circle',
+            cavity_shape='cylinder',
+            end_correction=0.3,
+            c=344,
+        )
+
+        self.assertEqual(calculated, expected)
+
+        expected = 103.879
+        calculated = helmholtz_resonant_frequency(
+            opening_diameter=(30),
+            opening_length=50,
+            cavity_dimensions=[100, 500],
+            opening_shape='square',
+            cavity_shape='prism',
+            end_correction=0.0,
+            c=344,
+        )
+
+        self.assertEqual(calculated, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add functionality for calculating the resonance frequency for Helmholtz absorbers with square or circular openings and prismatic or cylindrical cavities.

![image](https://github.com/MatiasCarbone/acoustician-tools/assets/96927246/b79cca4d-873f-454c-a0d7-4c66933042ac)